### PR TITLE
feat: Increase maxBuffer size for execSync in GitVersion class

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7862,7 +7862,8 @@ class GitVersion {
             const output = (0, child_process_1.execSync)(cmd, {
                 cwd: this.options.folder,
                 encoding: 'utf8',
-                stdio: ['pipe', 'pipe', 'pipe']
+                stdio: ['pipe', 'pipe', 'pipe'],
+                maxBuffer: 1024 * 1024 * 50
             });
             return output.split('\n').filter(line => line.trim() !== '');
         }

--- a/src/git-version.ts
+++ b/src/git-version.ts
@@ -308,7 +308,8 @@ export class GitVersion {
       const output = execSync(cmd, {
         cwd: this.options.folder,
         encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'pipe']
+        stdio: ['pipe', 'pipe', 'pipe'],
+        maxBuffer: 1024 * 1024 * 50
       })
 
       return output.split('\n').filter(line => line.trim() !== '')


### PR DESCRIPTION
This pull request introduces a small change to the `GitVersion` class to improve the reliability of executing Git commands with large output.

* Increased the `maxBuffer` option in the `execSync` call within `src/git-version.ts` to 50MB, preventing buffer overflow errors when handling large command outputs.